### PR TITLE
[expo-passkey] Use Base64URL encoding on iOS

### DIFF
--- a/android/src/main/java/expo/modules/expoclavepasskey/ClavePasskeyException.kt
+++ b/android/src/main/java/expo/modules/expoclavepasskey/ClavePasskeyException.kt
@@ -1,0 +1,87 @@
+package expo.modules.expoclavepasskey
+
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialInterruptedException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.CreateCredentialUnknownException
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
+
+/**
+ * Class to represent passkey errors
+ * @param code Error code
+ * @param message Error message, it mustn't contain whitespace
+ */
+class ClavePasskeyException(val code: String, val message: String) { }
+
+/**
+ * Converts registration exception to error code and error message
+ * @param e Exception
+ */
+fun convertRegistrationException(e: CreateCredentialException): ClavePasskeyException {
+    when (e) {
+        is CreatePublicKeyCredentialDomException -> {
+            return ClavePasskeyException("10601", e.domError.toString())
+        }
+        is CreateCredentialCancellationException -> {
+            return ClavePasskeyException("10602", "UserCancelled")
+        }
+        is CreateCredentialInterruptedException -> {
+            return ClavePasskeyException("10603", "Interrupted")
+        }
+        is CreateCredentialProviderConfigurationException -> {
+            return ClavePasskeyException("10604", "NotConfigured")
+        }
+        is CreateCredentialUnknownException -> {
+            return ClavePasskeyException("10605", "UnknownError")
+        }
+        is CreateCredentialUnsupportedException -> {
+            return ClavePasskeyException("10606", "NotSupported")
+        }
+        else -> {
+            return ClavePasskeyException("10608", e.toString())
+        }
+    }
+}
+
+/**
+ * Converts authentication exception to error code and error message
+ * @param e Exception
+ */
+fun convertAuthenticationException(e: GetCredentialException): ClavePasskeyException {
+    when (e) {
+        is GetPublicKeyCredentialDomException -> {
+            return ClavePasskeyException("10601", e.domError.toString())
+        }
+        is GetCredentialCancellationException -> {
+            return ClavePasskeyException("10602", "UserCancelled")
+        }
+        is GetCredentialInterruptedException -> {
+            return ClavePasskeyException("10603", "Interrupted")
+        }
+        is GetCredentialProviderConfigurationException -> {
+            return ClavePasskeyException("10604", "NotConfigured")
+        }
+        is GetCredentialUnknownException -> {
+            return ClavePasskeyException("10605", "UnknownError")
+        }
+        is GetCredentialUnsupportedException -> {
+            return ClavePasskeyException("10606", "NotSupported")
+        }
+        is NoCredentialException -> {
+            return ClavePasskeyException("10607", "NoCredentials")
+        }
+        else -> {
+            return ClavePasskeyException("10608", e.toString())
+        }
+    }
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
     - ExpoModulesCore
   - Expo (50.0.2):
     - ExpoModulesCore
-  - ExpoClavePasskey (0.1.0):
+  - ExpoClavePasskey (0.5.6):
     - ExpoModulesCore
   - ExpoFileSystem (16.0.4):
     - ExpoModulesCore
@@ -1260,7 +1260,7 @@ SPEC CHECKSUMS:
   EXConstants: 988aa430ca0f76b43cd46b66e7fae3287f9cc2fc
   EXFont: 21b9c760abd593ce8f0d5386b558ced76018506f
   Expo: 6c6526e76864e140363431722b22d0fa3cdeafd2
-  ExpoClavePasskey: 23eafacc73fc901fec631d41379a17a73afc70dc
+  ExpoClavePasskey: 430da987348fe221571df10339070c87f5c85bea
   ExpoFileSystem: 39e454b8e7f2358ae2c8f8ec255fede4c3039493
   ExpoKeepAwake: 0f5cad99603a3268e50af9a6eb8b76d0d9ac956c
   ExpoModulesCore: f103ff1346136b2926e1654f32b3f45ab0b74830

--- a/ios/Base64UrlExtension.swift
+++ b/ios/Base64UrlExtension.swift
@@ -1,0 +1,40 @@
+//
+//  Base64UrlExtension.swift
+//  ExpoClavePasskey
+//
+//  Created by Hamza Karabağ on 23.03.2024.
+//
+
+import Foundation
+
+/// Converts Base64URL string to Base64
+func base64UrlToBase64(_ base64Url: String) -> String {
+    var base64 = base64Url
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    if base64.count % 4 != 0 {
+        base64.append(String(repeating: "=", count: 4 - base64.count % 4))
+    }
+    return base64
+}
+
+/// Converts Base64 string to Base64URL
+func base64ToBase64Url(_ base64: String) -> String {
+    let base64Url = base64
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+    return base64Url
+}
+
+/// Extension of Data class for Base64URL conversions
+extension Data {
+    static func fromBase64Url(_ value: String) -> Data? {
+        let base64Value = base64UrlToBase64(value)
+        return Data(base64Encoded: base64Value)
+    }
+    
+    func toBase64Url() -> String {
+        return base64ToBase64Url(self.base64EncodedString())
+    }
+}

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -8,19 +8,22 @@
 import Foundation
 import ExpoModulesCore
 
+/// Struct to represent Passkey errors.
 struct PasskeyError: Error {
+    // Error code
     let code: String
+    // Error message, it mustn't containt whitespace
     let message: String
     
     // Common errors with Passkey
-    static let NotSupported     = Self(code: "20601", message: "Not supported")
-    static let RequestFailed    = Self(code: "20602", message: "Request failed")
-    static let Cancelled        = Self(code: "20603", message: "User cancelled")
-    static let InvalidChallenge = Self(code: "20604", message: "Invalid challenge")
-    static let InvalidRpId      = Self(code: "20605", message: "Invalid rpId")
-    static let InvalidUserId    = Self(code: "20606", message: "Invalid userId")
-    static let NotConfigured    = Self(code: "20607", message: "Not configured")
-    static let UnknownError     = Self(code: "20608", message: "Unknown error")
+    static let NotSupported     = Self(code: "20601", message: "NotSupported")
+    static let RequestFailed    = Self(code: "20602", message: "RequestFailed")
+    static let Cancelled        = Self(code: "20603", message: "UserCancelled")
+    static let InvalidChallenge = Self(code: "20604", message: "InvalidChallenge")
+    static let InvalidRpId      = Self(code: "20605", message: "InvalidRpId")
+    static let InvalidUserId    = Self(code: "20606", message: "InvalidUserId")
+    static let NotConfigured    = Self(code: "20607", message: "NotConfigured")
+    static let UnknownError     = Self(code: "20608", message: "UnknownError")
 }
 
 /// Extension of Promise that has rejection with Passkey Error

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -1,0 +1,31 @@
+//
+//  Errors.swift
+//  ExpoClavePasskey
+//
+//  Created by Hamza Karabağ on 23.03.2024.
+//
+
+import Foundation
+import ExpoModulesCore
+
+struct PasskeyError: Error {
+    let code: String
+    let message: String
+    
+    // Common errors with Passkey
+    static let NotSupported     = Self(code: "20601", message: "Not supported")
+    static let RequestFailed    = Self(code: "20602", message: "Request failed")
+    static let Cancelled        = Self(code: "20603", message: "User cancelled")
+    static let InvalidChallenge = Self(code: "20604", message: "Invalid challenge")
+    static let InvalidRpId      = Self(code: "20605", message: "Invalid rpId")
+    static let InvalidUserId    = Self(code: "20606", message: "Invalid userId")
+    static let NotConfigured    = Self(code: "20607", message: "Not configured")
+    static let UnknownError     = Self(code: "20608", message: "Unknown error")
+}
+
+/// Extension of Promise that has rejection with Passkey Error
+extension Promise {
+    func rejectWith(passkeyError: PasskeyError) {
+        self.reject(passkeyError.code, passkeyError.message)
+    }
+}

--- a/ios/ExpoClavePasskeyModule.swift
+++ b/ios/ExpoClavePasskeyModule.swift
@@ -13,9 +13,9 @@ public class ExpoClavePasskeyModule: Module {
         /// - `userId`: User ID (encoded in Base64URL)
         /// - `promise`: Javascript Promise
         AsyncFunction("register") { ( challenge: String,
-                                      displayName: String,
                                       rpId: String,
                                       userId: String,
+                                      displayName: String,
                                       promise: Promise ) in
             
             guard let challenge = Data.fromBase64Url(challenge) else {
@@ -69,8 +69,8 @@ public class ExpoClavePasskeyModule: Module {
         /// - `rpId`: Relaying Party ID
         /// - `promise`: Javascript Promise
         AsyncFunction("authenticate") { (challenge: String,
-                                         allowedCredentials: [String],
                                          rpId: String,
+                                         allowedCredentials: [String],
                                          promise: Promise) in
             guard let challenge = Data.fromBase64Url(challenge) else {
                 promise.rejectWith(passkeyError: PasskeyError.InvalidChallenge)

--- a/ios/ExpoClavePasskeyModule.swift
+++ b/ios/ExpoClavePasskeyModule.swift
@@ -2,8 +2,6 @@ import ExpoModulesCore
 import AuthenticationServices
 
 public class ExpoClavePasskeyModule: Module {
-    var passKeyDelegate: PasskeyDelegate?
-
     public func definition() -> ModuleDefinition {
         Name("ExpoClavePasskey")
         
@@ -34,7 +32,7 @@ public class ExpoClavePasskeyModule: Module {
                 let platformProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: rpId)
                 let authRequest = platformProvider.createCredentialRegistrationRequest(challenge: challenge, name: displayName, userID: userId)
                 let authController = ASAuthorizationController(authorizationRequests: [authRequest])
-                let passkeyDelegate = PasskeyDelegate2();
+                let passkeyDelegate = PasskeyDelegate();
                 
                 // Perform authorization, check for the error and parse the result
                 passkeyDelegate.performAuth(for: authController, completion: { error, result in
@@ -92,7 +90,7 @@ public class ExpoClavePasskeyModule: Module {
                     return
                 }
                 let authController = ASAuthorizationController(authorizationRequests: [authRequest])
-                let passkeyDelegate = PasskeyDelegate2();
+                let passkeyDelegate = PasskeyDelegate();
                 passkeyDelegate.performAuth(for: authController, completion: { error, result in
                     if (error != nil) {
                         promise.rejectWith(passkeyError: self.convertNativeError(error: error!))

--- a/ios/PasskeyDelegate.swift
+++ b/ios/PasskeyDelegate.swift
@@ -8,11 +8,107 @@
 import Foundation
 import AuthenticationServices
 
+struct PasskeyRegistrationResult {
+    var credentialID: Data
+    var rawAttestationObject: Data
+    var rawClientDataJSON: Data
+}
+
+struct PasskeyAuthenticationResult {
+    var credentialID: Data
+    var rawAuthenticatorData: Data
+    var rawClientDataJSON: Data
+    var signature: Data
+    var userID: Data
+}
+
+struct PasskeyResult {
+    var registrationResult: PasskeyRegistrationResult?
+    var authenticationResult: PasskeyAuthenticationResult?
+}
+
+typealias PasskeyCallback = (_ error: Error?, _ result: PasskeyResult?) -> Void;
+
+@available(iOS 15.0, *)
+var delegates = Set<PasskeyDelegate2>();
+
+@available(iOS 15.0, *)
+class PasskeyDelegate2: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    private var completion: PasskeyCallback?;
+    
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let keyWindow = UIApplication.shared.windows.first(where: \.isKeyWindow) else {
+            fatalError("No key window found")
+        }
+        return keyWindow
+    }
+    
+    func performAuth(for controller: ASAuthorizationController, completion: @escaping PasskeyCallback) {
+        self.completion = completion;
+        
+        // Set delegate for the controller and add self to existing delegates
+        controller.delegate = self;
+        delegates.insert(self);
+        
+        controller.presentationContextProvider = self;
+        controller.performRequests();
+    }
+    
+    // On authorization success
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        // Check if authorization was passkey registration or passkey authentication
+        if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
+            // Registration
+            self.onRegister(credential: credential)
+        } else if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
+            // Authentication
+            self.onAuthenticate(credential: credential)
+        } else {
+            self.completion!(PasskeyError.RequestFailed, nil)
+        }
+        
+        // Clear completion function and remove delegate
+        self.completion = nil
+        delegates.remove(self)
+    }
+
+    // On authorization failure
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        self.completion!(error, nil)
+        self.completion = nil
+        delegates.remove(self)
+    }
+    
+    func onRegister(credential: ASAuthorizationPlatformPublicKeyCredentialRegistration) -> Void {
+      if let rawAttestationObject = credential.rawAttestationObject {
+        // Parse the authorization credential and resolve the callback
+        let registrationResult = PasskeyRegistrationResult(credentialID: credential.credentialID,
+                                                           rawAttestationObject: rawAttestationObject,
+                                                           rawClientDataJSON: credential.rawClientDataJSON);
+        self.completion!(nil, PasskeyResult(registrationResult: registrationResult));
+      } else {
+        // Authorization credential was malformed, throw an error
+        self.completion!(PasskeyError.RequestFailed, nil);
+      }
+    }
+    
+    func onAuthenticate(credential: ASAuthorizationPlatformPublicKeyCredentialAssertion) -> Void {
+      // Parse the authorization credential and resolve the callback
+      let authenticationResult = PasskeyAuthenticationResult(credentialID: credential.credentialID,
+                                                             rawAuthenticatorData: credential.rawAuthenticatorData,
+                                                             rawClientDataJSON: credential.rawClientDataJSON,
+                                                             signature: credential.signature,
+                                                             userID: credential.userID);
+      self.completion!(nil, PasskeyResult(authenticationResult: authenticationResult));
+    }
+    
+}
+
 class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-  private var _completion: (_ error: Error?, _ result: PassKeyResult?) -> Void;
+  private var _completion: (_ error: Error?, _ result: PasskeyResult?) -> Void;
   
   // Initializes delegate with a completion handler (callback function)
-  init(completionHandler: @escaping (_ error: Error?, _ result: PassKeyResult?) -> Void) {
+  init(completionHandler: @escaping (_ error: Error?, _ result: PasskeyResult?) -> Void) {
     self._completion = completionHandler;
   }
   

--- a/ios/PasskeyDelegate.swift
+++ b/ios/PasskeyDelegate.swift
@@ -30,10 +30,10 @@ struct PasskeyResult {
 typealias PasskeyCallback = (_ error: Error?, _ result: PasskeyResult?) -> Void;
 
 @available(iOS 15.0, *)
-var delegates = Set<PasskeyDelegate2>();
+var delegates = Set<PasskeyDelegate>();
 
 @available(iOS 15.0, *)
-class PasskeyDelegate2: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     private var completion: PasskeyCallback?;
     
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
@@ -102,114 +102,4 @@ class PasskeyDelegate2: NSObject, ASAuthorizationControllerDelegate, ASAuthoriza
       self.completion!(nil, PasskeyResult(authenticationResult: authenticationResult));
     }
     
-}
-
-class PasskeyDelegate: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
-  private var _completion: (_ error: Error?, _ result: PasskeyResult?) -> Void;
-  
-  // Initializes delegate with a completion handler (callback function)
-  init(completionHandler: @escaping (_ error: Error?, _ result: PasskeyResult?) -> Void) {
-    self._completion = completionHandler;
-  }
-  
-  // Perform the authorization request for a given ASAuthorizationController instance
-  @available(iOS 15.0, *)
-  @objc(performAuthForController:)
-  func performAuthForController(controller: ASAuthorizationController) {
-    controller.delegate = self;
-    controller.presentationContextProvider = self;
-    controller.performRequests();
-  }
-  
-  @available(iOS 13.0, *)
-  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-    return UIApplication.shared.keyWindow!;
-  }
-  
-  @available(iOS 13.0, *)
-  func authorizationController(
-      controller: ASAuthorizationController,
-      didCompleteWithError error: Error
-  ) {
-    // Authorization request returned an error
-    self._completion(error, nil);
-  }
-
-  @available(iOS 13.0, *)
-  func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-    // Check if Passkeys are supported on this OS version
-    if #available(iOS 15.0, *) {
-      /** We need to determine whether the request was a registration or authentication request and if a security key was used or not*/
-      
-      // Request was a registration request
-      if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
-        self.handlePlatformPublicKeyRegistrationResponse(credential: credential)
-      //Request was an authentication request
-      } else if let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
-        self.handlePlatformPublicKeyAssertionResponse(credential: credential)
-      // Request was a registration request with security key
-      } else if let credential = authorization.credential as? ASAuthorizationSecurityKeyPublicKeyCredentialRegistration {
-        self.handleSecurityKeyPublicKeyRegistrationResponse(credential: credential)
-      // Request was an authentication request with security key
-      } else if let credential = authorization.credential as? ASAuthorizationSecurityKeyPublicKeyCredentialAssertion {
-        self.handleSecurityKeyPublicKeyAssertionResponse(credential: credential)
-      } else {
-        self._completion(PassKeyError.requestFailed, nil)
-      }
-    } else {
-      // Authorization credential was malformed, throw an error
-      self._completion(PassKeyError.notSupported, nil);
-    }
-  }
-  
-  @available(iOS 15.0, *)
-  func handlePlatformPublicKeyRegistrationResponse(credential: ASAuthorizationPlatformPublicKeyCredentialRegistration) -> Void {
-    if let rawAttestationObject = credential.rawAttestationObject {
-      // Parse the authorization credential and resolve the callback
-      let registrationResult = PassKeyRegistrationResult(credentialID: credential.credentialID,
-                                                         rawAttestationObject: rawAttestationObject,
-                                                         rawClientDataJSON: credential.rawClientDataJSON);
-      self._completion(nil, PassKeyResult(registrationResult: registrationResult));
-    } else {
-      // Authorization credential was malformed, throw an error
-      self._completion(PassKeyError.requestFailed, nil);
-    }
-  }
-  
-  @available(iOS 15.0, *)
-  func handleSecurityKeyPublicKeyRegistrationResponse(credential: ASAuthorizationSecurityKeyPublicKeyCredentialRegistration) -> Void {
-    if let rawAttestationObject = credential.rawAttestationObject {
-      // Parse the authorization credential and resolve the callback
-      let registrationResult = PassKeyRegistrationResult(credentialID: credential.credentialID,
-                                                         rawAttestationObject: rawAttestationObject,
-                                                         rawClientDataJSON: credential.rawClientDataJSON);
-      self._completion(nil, PassKeyResult(registrationResult: registrationResult));
-    } else {
-      // Authorization credential was malformed, throw an error
-      self._completion(PassKeyError.requestFailed, nil);
-    }
-  }
-  
-  @available(iOS 15.0, *)
-  func handlePlatformPublicKeyAssertionResponse(credential: ASAuthorizationPlatformPublicKeyCredentialAssertion) -> Void {
-    // Parse the authorization credential and resolve the callback
-    let assertionResult = PassKeyAssertionResult(credentialID: credential.credentialID,
-                                                 rawAuthenticatorData: credential.rawAuthenticatorData,
-                                                 rawClientDataJSON: credential.rawClientDataJSON,
-                                                 signature: credential.signature,
-                                                 userID: credential.userID);
-    self._completion(nil, PassKeyResult(assertionResult: assertionResult));
-  }
-  
-  
-  @available(iOS 15.0, *)
-  func handleSecurityKeyPublicKeyAssertionResponse(credential: ASAuthorizationSecurityKeyPublicKeyCredentialAssertion) -> Void {
-    // Parse the authorization credential and resolve the callback
-    let assertionResult = PassKeyAssertionResult(credentialID: credential.credentialID,
-                                                 rawAuthenticatorData: credential.rawAuthenticatorData,
-                                                 rawClientDataJSON: credential.rawClientDataJSON,
-                                                 signature: credential.signature,
-                                                 userID: credential.userID);
-    self._completion(nil, PassKeyResult(assertionResult: assertionResult));
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getclave/expo-passkey",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Expo module for interacting with Passkeys in Clave",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/ExpoClavePasskey.errors.ts
+++ b/src/ExpoClavePasskey.errors.ts
@@ -33,6 +33,13 @@ export class InvalidChallengeError extends Error {
     }
 }
 
+export class InvalidRpIdError extends Error {
+    constructor() {
+        super('The provided rpId was invalid');
+        this.name = 'InvalidRpIdError';
+    }
+}
+
 export class InvalidUserIdError extends Error {
     constructor() {
         super('The provided userId was invalid');
@@ -87,6 +94,12 @@ export function handleNativeError(_error: unknown): Error {
         }
         case 'InvalidChallenge': {
             return new InvalidChallengeError();
+        }
+        case 'InvalidRpId': {
+            return new InvalidRpIdError();
+        }
+        case 'InvalidUserId': {
+            return new InvalidUserIdError();
         }
         case 'NotConfigured': {
             return new NotConfiguredError();

--- a/src/ExpoClavePasskey.errors.ts
+++ b/src/ExpoClavePasskey.errors.ts
@@ -1,97 +1,107 @@
-export interface PasskeyError {
-    error: string;
-    message: string;
+export class UnknownError extends Error {
+    constructor() {
+        super('An unknown error occurred');
+        this.name = 'UnknownError';
+    }
 }
 
-export const UnknownError: PasskeyError = {
-    error: 'Unknown error',
-    message: 'An unknown error occurred',
-};
+export class NotSupportedError extends Error {
+    constructor() {
+        super('Passkeys are not supported on this device');
+        this.name = 'NotSupportedError';
+    }
+}
 
-export const NotSupportedError: PasskeyError = {
-    error: 'NotSupported',
-    message:
-        'Passkeys are not supported on this device. iOS 15 and above is required to use Passkeys',
-};
+export class RequestFailedError extends Error {
+    constructor() {
+        super('The request failed, no credentials were returned');
+        this.name = 'RequestFailedError';
+    }
+}
 
-export const RequestFailedError: PasskeyError = {
-    error: 'RequestFailed',
-    message: 'The request failed. No Credentials were returned.',
-};
+export class UserCancelledError extends Error {
+    constructor() {
+        super('The user cancelled the request');
+        this.name = 'UserCancelledError';
+    }
+}
 
-export const UserCancelledError: PasskeyError = {
-    error: 'UserCancelled',
-    message: 'The user cancelled the request.',
-};
+export class InvalidChallengeError extends Error {
+    constructor() {
+        super('The provided challenge was invalid');
+        this.name = 'InvalidChallengeError';
+    }
+}
 
-export const InvalidChallengeError: PasskeyError = {
-    error: 'InvalidChallenge',
-    message: 'The provided challenge was invalid',
-};
+export class InvalidUserIdError extends Error {
+    constructor() {
+        super('The provided userId was invalid');
+        this.name = 'InvalidUserIdError';
+    }
+}
 
-export const InvalidUserIdError: PasskeyError = {
-    error: 'InvalidUserId',
-    message: 'The provided userId was invalid',
-};
+export class NotConfiguredError extends Error {
+    constructor() {
+        super('Your app is not properly configured');
+        this.name = 'NotConfiguredError';
+    }
+}
 
-export const NotConfiguredError: PasskeyError = {
-    error: 'NotConfigured',
-    message: 'Your app is not properly configured. Refer to the docs for help.',
-};
+export class NoCredentialsError extends Error {
+    constructor() {
+        super('No viable credential is available for the user');
+        this.name = 'NoCredentialsError';
+    }
+}
 
-export const NoCredentialsError: PasskeyError = {
-    error: 'NoCredentials',
-    message: 'No viable credential is available for the user.',
-};
+export class InterruptedError extends Error {
+    constructor() {
+        super('The operation was interrupted and may be retried');
+        this.name = 'InterruptedError';
+    }
+}
 
-export const InterruptedError: PasskeyError = {
-    error: 'Interrupted',
-    message: 'The operation was interrupted and may be retried.',
-};
+export class NativeError extends Error {
+    constructor(message: string) {
+        super('An unknown error occurred');
+        this.name = 'NativeError';
+    }
+}
 
-export const NativeError = (
-    message = 'An unknown error occurred',
-): PasskeyError => {
-    return {
-        error: 'Native error',
-        message: message,
-    };
-};
-
-export function handleNativeError(_error: unknown): PasskeyError {
+export function handleNativeError(_error: unknown): Error {
     if (typeof _error !== 'object') {
-        return UnknownError;
+        return new UnknownError();
     }
 
     const error = String(_error).split(' ')[1];
 
     switch (error) {
         case 'NotSupported': {
-            return NotSupportedError;
+            return new NotSupportedError();
         }
         case 'RequestFailed': {
-            return RequestFailedError;
+            return new RequestFailedError();
         }
         case 'UserCancelled': {
-            return UserCancelledError;
+            return new UserCancelledError();
         }
         case 'InvalidChallenge': {
-            return InvalidChallengeError;
+            return new InvalidChallengeError();
         }
         case 'NotConfigured': {
-            return NotConfiguredError;
+            return new NotConfiguredError();
         }
         case 'Interrupted': {
-            return InterruptedError;
+            return new InterruptedError();
         }
         case 'NoCredentials': {
-            return NoCredentialsError;
+            return new NoCredentialsError();
         }
         case 'UnknownError': {
-            return UnknownError;
+            return new UnknownError();
         }
         default: {
-            return NativeError(error);
+            return new NativeError(error);
         }
     }
 }

--- a/src/ExpoClavePasskey.types.ts
+++ b/src/ExpoClavePasskey.types.ts
@@ -1,3 +1,116 @@
+export type RelyingParty = {
+    /** Relying Party ID, can be any string */
+    id: string;
+    /** Relying Party name, can be any string */
+    name: string;
+};
+
+export type User = {
+    /** User ID, encoded as base64url */
+    id: string;
+    /** User name, can be any string */
+    name: string;
+    /** User display name, can be any string. This is what is shown to the user */
+    displayName: string;
+};
+
+export type PublicKeyCredentialParameters = {
+    /** @note Credential type is always 'public-key' */
+    type: string;
+    /**
+     * The algorithm used for the credential
+     * - `-7`: P256
+     * - `-257`: RS256
+     */
+    alg: number;
+};
+
+export type CredentialDescriptor = {
+    /** @note Credential type is always 'public-key' */
+    type: string;
+    /** ID for the credential, base64url encoded */
+    id: string;
+    /**
+     * The authenticator transports that the caller is willing to use.
+     * @note For mobile phone authenticators, use 'internal'
+     */
+    transports?: Array<
+        'usb' | 'ble' | 'nfc' | 'smart-card' | 'hybrid' | 'internal'
+    >;
+};
+
+/**
+ * Specifies requirements regarding authenticator attributes.
+ */
+export type AuthenticatorSelectionCriteria = {
+    /**
+     * "platform": Use platform specific authenticator.
+     * "cross-platform": Use cross-platform authenticator (e.g. security key)
+     * @note To use mobile phone as authenticator, set this to "platform"
+     */
+    authenticatorAttachment: 'platform' | 'cross-platform';
+    /**
+     * Whether the authenticator should support resident keys (aka passkeys).
+     * @note Default is "discouraged" if `requireResidentKey` is false and
+     * "required" else.
+     */
+    residentKey: 'discouraged' | 'preferred' | 'required';
+    /**
+     * Whether to use resident keys (aka passkeys).
+     */
+    requireResidentKey: boolean;
+    /**
+     * Specifies requirements regarding user verification.
+     * @note For mobile phone authenticators, this is ignored.
+     */
+    userVerification: 'preferred' | 'required' | 'discouraged';
+};
+
+export type PasskeyCreateOptions = {
+    /** Relying party options */
+    rp: RelyingParty;
+    /** User options */
+    user: User;
+    /** Challenge, base64url encoded */
+    challenge: string;
+    /** Public key credential params */
+    pubKeyCredParams: Array<PublicKeyCredentialParameters>;
+    /** Timeout for the operation, in milliseconds */
+    timeout?: number;
+    /** Credential IDs to excluded from creation */
+    excludeCredentials?: Array<CredentialDescriptor>;
+    /** Authenticator selection criteria */
+    authenticatorSelection?: AuthenticatorSelectionCriteria;
+    /** Information sent to relying party about the authenticator */
+    attestation?: 'none' | 'indirect' | 'direct' | 'enterprise';
+    /** Format of the attestation, can be ignored */
+    attestationFormats?: Array<string>;
+    /** Hints sent to authenticator, can be ignored */
+    hints?: Array<string>;
+    /** Extensions sent to authenticator, can be ignored */
+    extensions?: Record<string, unknown>;
+};
+
+export type PasskeyAuthenticationOptions = {
+    /** Challenge, base64url encoded */
+    challenge: string;
+    /** Timeout for the operation, in milliseconds */
+    timeout?: number;
+    /** Relying party ID */
+    rpId: RelyingParty['id'];
+    /** Allowed credentials for the operation */
+    allowCredentials?: Array<CredentialDescriptor>;
+    /**
+     * Specifies requirements regarding user verification.
+     * @note For mobile phone authenticators, this is ignored.
+     */
+    userVerification: 'preferred' | 'required' | 'discouraged';
+    /** Hints sent to authenticator, can be ignored */
+    hints?: Array<string>;
+    /** Extensions sent to authenticator, can be ignored */
+    extensions?: Record<string, unknown>;
+};
+
 /**
  * The available options for Passkey operations
  */

--- a/src/ExpoClavePasskey.types.ts
+++ b/src/ExpoClavePasskey.types.ts
@@ -1,3 +1,4 @@
+/** https://w3c.github.io/webauthn/#dictdef-publickeycredentialrpentity */
 export type RelyingParty = {
     /** Relying Party ID, can be any string */
     id: string;
@@ -5,6 +6,7 @@ export type RelyingParty = {
     name: string;
 };
 
+/** https://w3c.github.io/webauthn/#dictdef-publickeycredentialuserentity */
 export type User = {
     /** User ID, encoded as base64url */
     id: string;
@@ -14,17 +16,19 @@ export type User = {
     displayName: string;
 };
 
+/** https://w3c.github.io/webauthn/#dictdef-publickeycredentialparameters */
 export type PublicKeyCredentialParameters = {
     /** @note Credential type is always 'public-key' */
     type: string;
     /**
      * The algorithm used for the credential
-     * - `-7`: P256
+     * - `-7`: ES256 (Webauthn's default algorithm)
      * - `-257`: RS256
      */
     alg: number;
 };
 
+/** https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptor */
 export type CredentialDescriptor = {
     /** @note Credential type is always 'public-key' */
     type: string;
@@ -41,6 +45,7 @@ export type CredentialDescriptor = {
 
 /**
  * Specifies requirements regarding authenticator attributes.
+ * https://w3c.github.io/webauthn/#dictionary-authenticatorSelection
  */
 export type AuthenticatorSelectionCriteria = {
     /**
@@ -56,16 +61,17 @@ export type AuthenticatorSelectionCriteria = {
      */
     residentKey: 'discouraged' | 'preferred' | 'required';
     /**
-     * Whether to use resident keys (aka passkeys).
+     * Whether to use resident keys (aka passkeys). Default is false
      */
-    requireResidentKey: boolean;
+    requireResidentKey?: boolean;
     /**
-     * Specifies requirements regarding user verification.
+     * Specifies requirements regarding user verification. Default is "preferred".
      * @note For mobile phone authenticators, this is ignored.
      */
-    userVerification: 'preferred' | 'required' | 'discouraged';
+    userVerification?: 'preferred' | 'required' | 'discouraged';
 };
 
+/** https://w3c.github.io/webauthn/#dictionary-makecredentialoptions */
 export type PasskeyCreateOptions = {
     /** Relying party options */
     rp: RelyingParty;
@@ -91,146 +97,57 @@ export type PasskeyCreateOptions = {
     extensions?: Record<string, unknown>;
 };
 
+/** https://w3c.github.io/webauthn/#dictdef-authenticationresponsejson */
+export type PasskeyCreateResult = {
+    /** Credential ID, base64url encoded */
+    id: string;
+    /** Credential ID, same as `id` */
+    rawId: string;
+    type: 'webauthn.create';
+    response: {
+        /** Client data JSON, base64url encoded */
+        clientDataJSON: string;
+        /** Attestation object, base64url encoded */
+        attestationObject: string;
+    };
+};
+
+/** https://w3c.github.io/webauthn/#dictionary-assertion-options */
 export type PasskeyAuthenticationOptions = {
     /** Challenge, base64url encoded */
     challenge: string;
     /** Timeout for the operation, in milliseconds */
     timeout?: number;
     /** Relying party ID */
-    rpId: RelyingParty['id'];
+    rpId?: RelyingParty['id'];
     /** Allowed credentials for the operation */
     allowCredentials?: Array<CredentialDescriptor>;
     /**
-     * Specifies requirements regarding user verification.
+     * Specifies requirements regarding user verification. Default is "preferred".
      * @note For mobile phone authenticators, this is ignored.
      */
-    userVerification: 'preferred' | 'required' | 'discouraged';
+    userVerification?: 'preferred' | 'required' | 'discouraged';
     /** Hints sent to authenticator, can be ignored */
     hints?: Array<string>;
     /** Extensions sent to authenticator, can be ignored */
     extensions?: Record<string, unknown>;
 };
 
-/**
- * The available options for Passkey operations
- */
-export interface PasskeyOptions {
-    withSecurityKey: boolean; // iOS only
-}
-
-// https://www.w3.org/TR/webauthn-2/#dictionary-credential-descriptor
-export interface PublicKeyCredentialDescriptor {
-    type: string;
+/** https://w3c.github.io/webauthn/#dictdef-authenticatorassertionresponsejson */
+export type PasskeyAuthenticationResult = {
+    /** Credential ID, base64url encoded */
     id: string;
-    transports?: Array<string>;
-}
-
-/**
- * The FIDO2 Attestation Request
- * https://www.w3.org/TR/webauthn-2/#dictionary-makecredentialoptions
- */
-export interface PasskeyRegistrationRequest {
-    challenge: string;
-    rp: {
-        id: string;
-        name: string;
-    };
-    user: {
-        id: string;
-        name: string;
-        displayName: string;
-    };
-    pubKeyCredParams: Array<{ type: string; alg: number }>;
-    timeout?: number;
-    authenticatorSelection?: {
-        authenticatorAttachment?: AuthenticatorAttachment;
-        requireResidentKey?: boolean;
-        residentKey?: string;
-        userVerification?: string;
-    };
-    attestation?: string;
-    extensions?: Record<string, unknown>;
-}
-
-/**
- * The FIDO2 Attestation Result
- */
-export interface PasskeyRegistrationResult {
-    id: string;
+    /** Credential ID, same as `id` */
     rawId: string;
-    type?: string;
+    type: 'webauthn.get';
     response: {
-        clientDataJSON: string;
-        attestationObject: string;
-    };
-}
-
-/**
- * The FIDO2 Assertion Request
- * https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options
- */
-export interface PasskeyAuthenticationRequest {
-    challenge: string;
-    rpId: string;
-    timeout?: number;
-    allowCredentials?: Array<PublicKeyCredentialDescriptor>;
-    userVerification?: string;
-    extensions?: Record<string, unknown>;
-}
-
-/**
- * The FIDO2 Assertion Result
- */
-export interface PasskeyAuthenticationResult {
-    id: string;
-    rawId: string;
-    type?: string;
-    response: {
+        /** Authenticator data, base64url encoded */
         authenticatorData: string;
+        /** Client data JSON, base64url encoded */
         clientDataJSON: string;
+        /** Signature, base64url encoded */
         signature: string;
-        userHandle: string;
+        /** User handle, base64url encoded */
+        userHandle?: string;
     };
-}
-
-export type AuthenticatorAttachment = 'platform' | 'cross-platform';
-
-export type AuthenticatorTransport =
-    | 'usb'
-    | 'ble'
-    | 'nfc'
-    | 'internal'
-    | 'hybrid';
-
-export type AuthenticatorType =
-    | 'auto'
-    | 'local'
-    | 'extern'
-    | 'roaming'
-    | 'both';
-
-export interface CommonOptions {
-    userVerification: string;
-    authenticatorType: AuthenticatorType;
-    timeout: number;
-    debug: boolean;
-}
-
-export interface CreateOptions extends CommonOptions {
-    rp: {
-        id: string;
-        name: string;
-    };
-    displayName: string;
-    attestation: boolean;
-    discoverable: string;
-    withSecurityKey: boolean;
-}
-
-export interface SignOptions extends CommonOptions {
-    rpId: string;
-    mediation: 'optional' | 'conditional' | 'required' | 'silent';
-    withSecurityKey: boolean;
-    /** Don't convert credentials id's to base64url */
-    preserveCredentials: boolean;
-}
+};

--- a/src/ExpoClavePasskey.types.ts
+++ b/src/ExpoClavePasskey.types.ts
@@ -103,7 +103,7 @@ export type PasskeyCreateResult = {
     id: string;
     /** Credential ID, same as `id` */
     rawId: string;
-    type: 'webauthn.create';
+    type: 'public-key';
     response: {
         /** Client data JSON, base64url encoded */
         clientDataJSON: string;
@@ -139,7 +139,7 @@ export type PasskeyAuthenticationResult = {
     id: string;
     /** Credential ID, same as `id` */
     rawId: string;
-    type: 'webauthn.get';
+    type: 'public-key';
     response: {
         /** Authenticator data, base64url encoded */
         authenticatorData: string;

--- a/src/NativeAndroid.ts
+++ b/src/NativeAndroid.ts
@@ -1,101 +1,56 @@
 import { handleNativeError } from './ExpoClavePasskey.errors';
 import {
-    PasskeyAuthenticationRequest,
+    PasskeyAuthenticationOptions,
     PasskeyAuthenticationResult,
-    PasskeyRegistrationRequest,
-    PasskeyRegistrationResult,
+    PasskeyCreateOptions,
+    PasskeyCreateResult,
 } from './ExpoClavePasskey.types';
 import ExpoClavePasskey from './ExpoClavePasskeyModule';
-import * as utils from './utils';
 
 export class NativeAndroid {
     /**
      * Android implementation of the registration process
-     *
-     * @param request The FIDO2 Attestation Request in JSON format
+     * @param `request` The FIDO2 Attestation Request in JSON format
      * @returns The FIDO2 Attestation Result in JSON format
      */
     public static async register(
-        request: PasskeyRegistrationRequest,
-    ): Promise<PasskeyRegistrationResult> {
-        const nativeRequest = this.prepareRegistrationRequest(request);
-
+        request: PasskeyCreateOptions,
+    ): Promise<PasskeyCreateResult> {
         try {
             const response = await ExpoClavePasskey.register(
-                JSON.stringify(nativeRequest),
+                JSON.stringify(request),
             );
-            return this.handleNativeResponse(JSON.parse(response));
-        } catch (error) {
+            return this.parseResponse(JSON.parse(response));
+        } catch (error: unknown) {
             throw handleNativeError(error);
         }
     }
 
     /**
      * Android implementation of the authentication process
-     *
-     * @param request The FIDO2 Assertion Request in JSON format
+     * @param `request` The FIDO2 Assertion Request in JSON format
      * @returns The FIDO2 Assertion Result in JSON format
      */
     public static async authenticate(
-        request: PasskeyAuthenticationRequest,
+        request: PasskeyAuthenticationOptions,
     ): Promise<PasskeyAuthenticationResult> {
-        const nativeRequest = this.prepareAuthRequest(request);
-
         try {
             const response = await ExpoClavePasskey.authenticate(
-                JSON.stringify(nativeRequest),
+                JSON.stringify(request),
             );
-            return this.handleNativeResponse(JSON.parse(response));
-        } catch (error) {
+            return this.parseResponse(JSON.parse(response));
+        } catch (error: unknown) {
             throw handleNativeError(error);
         }
     }
 
-    /**
-     * Prepares the assertion request for Android
-     */
-    public static prepareAuthRequest(
-        _request: PasskeyAuthenticationRequest,
-    ): object {
-        const request = { ..._request };
-        // Convert the credentials to Base64URL
-        if (request.allowCredentials != undefined) {
-            request.allowCredentials = request.allowCredentials.map(
-                (credential) => {
-                    return {
-                        ...credential,
-                        id: utils.base64ToBase64Url(credential.id),
-                    };
-                },
-            );
-        }
-        request.challenge = utils.base64ToBase64Url(request.challenge);
-
-        return request;
-    }
-
-    /**
-     * Prepares the assertion request for Android
-     */
-    public static prepareRegistrationRequest(
-        _request: PasskeyRegistrationRequest,
-    ): object {
-        // Android requires base64url encoding for user id and challenge
-        const request = { ..._request };
-        request.user.id = utils.base64ToBase64Url(request.user.id);
-        request.challenge = utils.base64ToBase64Url(request.challenge);
-        return request;
-    }
-
-    private static handleNativeResponse(
-        response: PasskeyRegistrationResult & PasskeyAuthenticationResult,
-    ): PasskeyRegistrationResult & PasskeyAuthenticationResult {
-        const id = response.id;
-
+    /** Adds rawId to the Android response */
+    private static parseResponse<AndroidResponse extends { id: string }>(
+        response: AndroidResponse,
+    ): AndroidResponse {
         return {
             ...response,
-            id,
-            rawId: id,
+            rawId: response.id,
         };
     }
 }

--- a/src/NativeiOS.ts
+++ b/src/NativeiOS.ts
@@ -78,8 +78,8 @@ export class NativeiOS {
         try {
             const response = await ExpoClavePasskey.authenticate(
                 request.challenge,
-                request.allowCredentials?.map(({ id }) => id) ?? [],
                 request.rpId,
+                request.allowCredentials?.map(({ id }) => id) ?? [],
             );
             return this.parseAuthenticationResult(response);
         } catch (error) {

--- a/src/NativeiOS.ts
+++ b/src/NativeiOS.ts
@@ -57,7 +57,7 @@ export class NativeiOS {
         return {
             id: result.credentialID,
             rawId: result.credentialID,
-            type: 'webauthn.create',
+            type: 'public-key',
             response: {
                 clientDataJSON: result.response.rawClientDataJSON,
                 attestationObject: result.response.rawAttestationObject,
@@ -96,7 +96,7 @@ export class NativeiOS {
         return {
             id: result.credentialID,
             rawId: result.credentialID,
-            type: 'webauthn.get',
+            type: 'public-key',
             response: {
                 clientDataJSON: result.response.rawClientDataJSON,
                 authenticatorData: result.response.rawAuthenticatorData,

--- a/src/NativeiOS.ts
+++ b/src/NativeiOS.ts
@@ -1,73 +1,66 @@
 import { handleNativeError } from './ExpoClavePasskey.errors';
 import {
-    PasskeyAuthenticationRequest,
+    PasskeyCreateOptions,
+    PasskeyCreateResult,
+    PasskeyAuthenticationOptions,
     PasskeyAuthenticationResult,
-    PasskeyRegistrationRequest,
-    PasskeyRegistrationResult,
 } from './ExpoClavePasskey.types';
-import * as utils from './utils';
 import ExpoClavePasskey from './ExpoClavePasskeyModule';
+
+export type iOSCreateResult = {
+    credentialID: string;
+    response: {
+        rawAttestationObject: string;
+        rawClientDataJSON: string;
+    };
+};
+
+export type iOSAuthenticationResult = {
+    credentialID: string;
+    userID: string;
+    response: {
+        rawAuthenticatorData: string;
+        rawClientDataJSON: string;
+        signature: string;
+    };
+};
 
 export class NativeiOS {
     /**
      * iOS implementation of the registration process
-     *
      * @param request The FIDO2 Attestation Request in JSON format
      * @param withSecurityKey A boolean indicating wether a security key should be used for registration
      * @returns The FIDO2 Attestation Result in JSON format
      */
     public static async register(
-        request: PasskeyRegistrationRequest,
-        withSecurityKey = false,
-    ): Promise<PasskeyRegistrationResult> {
-        // Extract the required data from the attestation request
-        const { rpId, challenge, name, userID } =
-            this.prepareRegistrationRequest(request);
-
+        request: PasskeyCreateOptions,
+    ): Promise<PasskeyCreateResult> {
         try {
             const response = await ExpoClavePasskey.register(
-                rpId,
-                challenge,
-                name,
-                userID,
-                withSecurityKey,
+                request.challenge,
+                request.rp.id,
+                request.user.id,
+                request.user.displayName,
             );
-            return this.handleNativeRegistrationResult(response);
+            return this.parseCreateResult(response);
         } catch (error) {
             throw handleNativeError(error);
         }
     }
 
     /**
-     * Extracts the data required for the attestation process on iOS from a given request
-     */
-    private static prepareRegistrationRequest(
-        request: PasskeyRegistrationRequest,
-    ): PasskeyiOSRegistrationData {
-        return {
-            rpId: request.rp.id,
-            challenge: request.challenge,
-            name: request.user.displayName,
-            userID: request.user.id,
-        };
-    }
-
-    /**
      * Transform the iOS-specific attestation result into a FIDO2 result
      */
-    private static handleNativeRegistrationResult(
-        result: PasskeyiOSRegistrationResult,
-    ): PasskeyRegistrationResult {
+    private static parseCreateResult(
+        result: iOSCreateResult,
+    ): PasskeyCreateResult {
         return {
             id: result.credentialID,
             rawId: result.credentialID,
+            type: 'webauthn.create',
             response: {
-                clientDataJSON: utils.base64ToBase64Url(
-                    result.response.rawClientDataJSON,
-                ),
-                attestationObject: utils.base64ToBase64Url(
-                    result.response.rawAttestationObject,
-                ),
+                clientDataJSON: result.response.rawClientDataJSON,
+                attestationObject: result.response.rawAttestationObject,
             },
         };
     }
@@ -80,67 +73,36 @@ export class NativeiOS {
      * @returns The FIDO2 Assertion Result in JSON format
      */
     public static async authenticate(
-        request: PasskeyAuthenticationRequest,
-        withSecurityKey = false,
+        request: PasskeyAuthenticationOptions,
     ): Promise<PasskeyAuthenticationResult> {
         try {
             const response = await ExpoClavePasskey.authenticate(
-                request.rpId,
                 request.challenge,
-                request.allowCredentials?.map((credential) => credential.id) ??
-                    [],
-                withSecurityKey,
+                request.allowCredentials?.map(({ id }) => id) ?? [],
+                request.rpId,
             );
-            return this.handleNativeAuthenticationResult(response);
+            return this.parseAuthenticationResult(response);
         } catch (error) {
             throw handleNativeError(error);
         }
     }
 
     /**
-     * Transform the iOS-specific assertion result into a FIDO2 result
+     * Transform the iOS-specific authentication result into a FIDO2 result
      */
-    private static handleNativeAuthenticationResult(
-        result: PasskeyiOSAuthenticationResult,
+    private static parseAuthenticationResult(
+        result: iOSAuthenticationResult,
     ): PasskeyAuthenticationResult {
         return {
             id: result.credentialID,
             rawId: result.credentialID,
+            type: 'webauthn.get',
             response: {
-                clientDataJSON: utils.base64ToBase64Url(
-                    result.response.rawClientDataJSON,
-                ),
-                authenticatorData: utils.base64ToBase64Url(
-                    result.response.rawAuthenticatorData,
-                ),
-                signature: utils.base64ToBase64Url(result.response.signature),
+                clientDataJSON: result.response.rawClientDataJSON,
+                authenticatorData: result.response.rawAuthenticatorData,
+                signature: result.response.signature,
                 userHandle: result.userID,
             },
         };
     }
-}
-
-interface PasskeyiOSRegistrationData {
-    rpId: string;
-    challenge: string;
-    name: string;
-    userID: string;
-}
-
-interface PasskeyiOSRegistrationResult {
-    credentialID: string;
-    response: {
-        rawAttestationObject: string;
-        rawClientDataJSON: string;
-    };
-}
-
-interface PasskeyiOSAuthenticationResult {
-    credentialID: string;
-    userID: string;
-    response: {
-        rawAuthenticatorData: string;
-        rawClientDataJSON: string;
-        signature: string;
-    };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,211 +1,138 @@
 import { Platform } from 'react-native';
 import { NotSupportedError } from './ExpoClavePasskey.errors';
 import {
-    AuthenticatorAttachment,
-    AuthenticatorTransport,
-    AuthenticatorType,
-    CommonOptions,
-    CreateOptions,
-    PasskeyAuthenticationRequest,
+    CredentialDescriptor,
+    PasskeyAuthenticationOptions,
     PasskeyAuthenticationResult,
-    PasskeyRegistrationRequest,
-    PasskeyRegistrationResult,
-    PublicKeyCredentialDescriptor,
-    SignOptions,
+    PasskeyCreateOptions,
+    PasskeyCreateResult,
 } from './ExpoClavePasskey.types';
 import { NativeAndroid } from './NativeAndroid';
 import { NativeiOS } from './NativeiOS';
 import * as utils from './utils';
 
 export class Passkey {
+    static credentialIdToDescriptor = (
+        credentialId: string,
+    ): CredentialDescriptor => ({
+        id: credentialId,
+        type: 'public-key',
+        transports: ['internal'],
+    });
+
+    /** Applies defaults to create request */
     static generateCreateRequest(
         userId: string,
         userName: string,
         challenge: string,
-        options: Partial<CreateOptions>,
-    ): PasskeyRegistrationRequest {
-        const request: PasskeyRegistrationRequest = {
+        overrides: Partial<PasskeyCreateOptions>,
+    ): PasskeyCreateOptions {
+        return {
             challenge,
-            rp: options.rp ?? {
+            rp: overrides.rp ?? {
                 id: 'getclave.io',
                 name: 'Clave',
             },
-            user: {
+            user: overrides.user ?? {
                 id: userId,
                 name: userName,
-                displayName: options.displayName ?? userName,
+                displayName: userName,
             },
-            pubKeyCredParams: [
+            pubKeyCredParams: overrides.pubKeyCredParams ?? [
                 { alg: -7, type: 'public-key' }, // ES256 (Webauthn's default algorithm)
             ],
-            authenticatorSelection: {
-                requireResidentKey: true,
+            authenticatorSelection: overrides.authenticatorSelection ?? {
+                authenticatorAttachment: 'platform',
                 residentKey: 'required',
-                authenticatorAttachment: this.getAuthAttachment(
-                    options.authenticatorType,
-                ),
+                requireResidentKey: true,
             },
         };
-
-        return request;
     }
 
-    static generateSignRequest(
+    /** Applies defaults to authentication request */
+    static generateAuthenticationRequest(
         credentialIds: Array<string>,
         challenge: string,
-        options: Partial<SignOptions>,
-    ): PasskeyAuthenticationRequest {
+        overrides: Partial<PasskeyAuthenticationOptions>,
+    ): PasskeyAuthenticationOptions {
         return {
             challenge,
-            rpId: options.rpId ?? 'getclave.io',
-            allowCredentials: credentialIds.map((credentialId) =>
-                this.credentialIdToDescriptor(credentialId, options),
-            ),
+            rpId: overrides.rpId ?? 'getclave.io',
+            allowCredentials: credentialIds.map(this.credentialIdToDescriptor),
         };
     }
 
     /**
      * Creates a new Passkey
      *
-     * @param userId The user's unique identifier
-     * @param userName The user's name
-     * @param challenge The FIDO2 Challenge in hex format
-     * @param options An object containing options for the registration process
-     * @returns The FIDO2 Attestation Result in JSON format
-     * @throws
+     * @param `userId`      The user's unique identifier
+     * @param `userName`    The user's name
+     * @param `challenge`   Challenge in hex format
+     * @param `override`    Overrides for credential creation
      */
     public static async create(
         userId: string,
         userName: string,
         challenge: string,
-        options: Partial<CreateOptions> = {},
-    ): Promise<PasskeyRegistrationResult> {
+        overrides: Partial<PasskeyCreateOptions> = {},
+    ): Promise<PasskeyCreateResult> {
         if (!Passkey.isSupported) {
-            throw NotSupportedError;
+            throw new NotSupportedError();
         }
 
-        challenge = utils.stripHexPrefix(challenge);
-        if (!utils.isValidHex(challenge)) {
-            throw new Error('Invalid hex challenge');
-        }
-
-        const challengeBase64 = utils.hextoBase64(challenge);
+        const challengeBase64Url = utils.hexToBase64Url(challenge);
 
         const request = this.generateCreateRequest(
             userId,
             userName,
-            challengeBase64,
-            options,
+            challengeBase64Url,
+            overrides,
         );
 
         if (Platform.OS === 'android') {
             return NativeAndroid.register(request);
         } else if (Platform.OS === 'ios') {
-            return NativeiOS.register(
-                request,
-                options.withSecurityKey ?? false,
-            );
-        }
-        throw NotSupportedError;
-    }
-
-    /**
-     * Authenticates using an existing Passkey and returns signature only
-     *
-     * @param credentialIds The credential IDs of the Passkey to authenticate with
-     * @param challenge The FIDO2 Challenge without formatting
-     * @options An object containing options for the authentication process
-     * @returns The FIDO2 Assertion Result in JSON format
-     * @throws
-     */
-    public static async sign(
-        credentialIds: Array<string>,
-        challenge: string,
-        options: Partial<SignOptions> = {},
-    ): Promise<string> {
-        if (!Passkey.isSupported) {
-            throw NotSupportedError;
-        }
-
-        challenge = utils.stripHexPrefix(challenge);
-        if (!utils.isValidHex(challenge)) {
-            throw new Error('Invalid hex challenge');
-        }
-
-        const challengeBase64 = utils.hextoBase64(challenge);
-
-        const request = this.generateSignRequest(
-            credentialIds,
-            challengeBase64,
-            options,
-        );
-
-        let authResponse: PasskeyAuthenticationResult;
-
-        if (Platform.OS === 'android') {
-            authResponse = await NativeAndroid.authenticate(request);
-        } else if (Platform.OS === 'ios') {
-            authResponse = await NativeiOS.authenticate(
-                request,
-                options.withSecurityKey ?? false,
-            );
+            return NativeiOS.register(request);
         } else {
-            throw NotSupportedError;
+            throw new NotSupportedError();
         }
-
-        const base64Decoded = utils.base64ToHex(
-            authResponse.response.signature,
-        );
-        const { r, s } = utils.derToRs(base64Decoded);
-        return ['0x', r, s].join('');
     }
 
     /**
-     * Authenticates using an existing Passkey and returns full response
-     *
-     * @param credentialIds The credential IDs of the Passkey to authenticate with
-     * @param challenge The FIDO2 Challenge without formatting
-     * @options An object containing options for the authentication process
+     * Authenticates using an existing Passkey
+     * @param `credentialIds` Allowed credential IDs, base64url encoded
+     * @param `challenge` Challenge in hex format
+     * @param `overrides` Overrides for authentication
      * @returns The FIDO2 Assertion Result in JSON format
      * @throws
      */
     public static async authenticate(
         credentialIds: Array<string>,
         challenge: string,
-        options: Partial<SignOptions> = {},
+        overrides: Partial<PasskeyAuthenticationOptions> = {},
     ): Promise<PasskeyAuthenticationResult> {
         if (!Passkey.isSupported) {
-            throw NotSupportedError;
+            throw new NotSupportedError();
         }
 
-        challenge = utils.stripHexPrefix(challenge);
-        if (!utils.isValidHex(challenge)) {
-            throw new Error('Invalid hex challenge');
-        }
-
-        const challengeBase64 = utils.hextoBase64(challenge);
-
-        const request = this.generateSignRequest(
+        const challengeBase64Url = utils.hexToBase64Url(challenge);
+        const request = this.generateAuthenticationRequest(
             credentialIds,
-            challengeBase64,
-            options,
+            challengeBase64Url,
+            overrides,
         );
 
         if (Platform.OS === 'android') {
             return NativeAndroid.authenticate(request);
         } else if (Platform.OS === 'ios') {
-            return NativeiOS.authenticate(
-                request,
-                options.withSecurityKey ?? false,
-            );
+            return NativeiOS.authenticate(request);
         } else {
-            throw NotSupportedError;
+            throw new NotSupportedError();
         }
     }
 
     /**
      * Checks if Passkeys are supported on the current device
-     *
      * @returns A boolean indicating whether Passkeys are supported
      */
     public static isSupported(): boolean {
@@ -219,49 +146,6 @@ export class Passkey {
 
         return false;
     }
-
-    static getAuthAttachment(
-        authType?: CommonOptions['authenticatorType'],
-    ): AuthenticatorAttachment | undefined {
-        if (authType === 'local') return 'platform';
-        if (authType === 'roaming' || authType === 'extern')
-            return 'cross-platform';
-        if (authType === 'both') return undefined; // The webauthn protocol considers `null` as invalid but `undefined` as "both"!
-
-        // the default case: "platform"
-        return 'platform';
-    }
-
-    static getTransports(
-        authType?: AuthenticatorType,
-    ): AuthenticatorTransport[] {
-        const local: AuthenticatorTransport[] = ['internal'];
-
-        // 'hybrid' was added mid-2022 in the specs and currently not yet available in the official dom types
-        // @ts-ignore
-        const roaming: AuthenticatorTransport[] = [
-            'hybrid',
-            'usb',
-            'ble',
-            'nfc',
-        ];
-
-        if (authType === 'local') return local;
-        if (authType == 'roaming' || authType === 'extern') return roaming;
-        if (authType === 'both') return [...local, ...roaming];
-
-        // the default case: "platform" (local)
-        return local;
-    }
-
-    static credentialIdToDescriptor = (
-        credentialId: string,
-        options: Partial<SignOptions> = {},
-    ): PublicKeyCredentialDescriptor => ({
-        id: credentialId,
-        type: 'public-key',
-        transports: this.getTransports(options.authenticatorType),
-    });
 }
 
 export * from './ExpoClavePasskey.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
     PasskeyAuthenticationResult,
     PasskeyCreateOptions,
     PasskeyCreateResult,
+    User,
 } from './ExpoClavePasskey.types';
 import { NativeAndroid } from './NativeAndroid';
 import { NativeiOS } from './NativeiOS';
@@ -22,8 +23,7 @@ export class Passkey {
 
     /** Applies defaults to create request */
     static generateCreateRequest(
-        userId: string,
-        userName: string,
+        user: User,
         challenge: string,
         overrides: Partial<PasskeyCreateOptions>,
     ): PasskeyCreateOptions {
@@ -33,11 +33,7 @@ export class Passkey {
                 id: 'getclave.io',
                 name: 'Clave',
             },
-            user: overrides.user ?? {
-                id: userId,
-                name: userName,
-                displayName: userName,
-            },
+            user: overrides.user ?? user,
             pubKeyCredParams: overrides.pubKeyCredParams ?? [
                 { alg: -7, type: 'public-key' }, // ES256 (Webauthn's default algorithm)
             ],
@@ -71,8 +67,7 @@ export class Passkey {
      * @param `override`    Overrides for credential creation
      */
     public static async create(
-        userId: string,
-        userName: string,
+        user: User,
         challenge: string,
         overrides: Partial<PasskeyCreateOptions> = {},
     ): Promise<PasskeyCreateResult> {
@@ -83,8 +78,7 @@ export class Passkey {
         const challengeBase64Url = utils.hexToBase64Url(challenge);
 
         const request = this.generateCreateRequest(
-            userId,
-            userName,
+            user,
             challengeBase64Url,
             overrides,
         );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,43 +18,19 @@ export function stripHexPrefix(hex: string): string {
     return hex.replace(/^0x/, '');
 }
 
-export const base64ToHex = (text: string) => {
-    return Buffer.from(text, 'base64').toString('hex');
-};
-
-/** Converts hex to buffer */
-export const hexToBuffer = (hex: string): Buffer => {
-    return Buffer.from(stripHexPrefix(hex), 'hex');
-};
-
-export const hextoBase64 = (hex: string) => {
-    return hexToBuffer(hex).toString('base64');
-};
-
-export const base64ToBase64Url = (text: string) => {
-    return text.replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
-};
-
 /**
- * Converts DER signature to R and S
- * R and S are hex strings
+ * Converts a hex string to a base64url encoded string.
+ * @param `hex` Hex string to convert.
+ * @returns Base64url encoded string.
  */
-export const derToRs = (derSignature: string): { r: string; s: string } => {
-    /*
-      DER signature format:
-      0x30 <length total> 0x02 <length r> <r> 0x02 <length s> <s>
-    */
-    const derBuffer = hexToBuffer(derSignature);
-
-    const rLen = derBuffer[3]!;
-    const rOffset = 4;
-    const rBuffer = derBuffer.slice(rOffset, rOffset + rLen);
-    const sLen = derBuffer[5 + rLen]!;
-    const sOffset = 6 + rLen;
-    const sBuffer = derBuffer.slice(sOffset, sOffset + sLen);
-
-    const r = rBuffer.toString('hex').replace(/^0+/, '');
-    const s = sBuffer.toString('hex').replace(/^0+/, '');
-
-    return { r, s };
-};
+export function hexToBase64Url(hex: string): string {
+    hex = stripHexPrefix(hex);
+    if (!isValidHex(hex)) {
+        throw new Error('Invalid hex string');
+    }
+    return Buffer.from(hex, 'hex')
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '');
+}


### PR DESCRIPTION
# WHAT
This PR migrates iOS Passkey code to use Base64URL encoding which simplifies most of the codebase

# WHY
Otherwise we have to write extra code for Android and iOS devices

# HOW
Swift doesn't have Base64URL encoding by default for its `Data` type. So this PR adds an extension for it that has `fromBase64Url` and `toBase64Url` functions to work around it.